### PR TITLE
[tests] Modify puppetforge tests when fetching from archive

### DIFF
--- a/tests/test_puppetforge.py
+++ b/tests/test_puppetforge.py
@@ -323,7 +323,8 @@ class TestPuppetForgeBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = PuppetForge(max_items=2, archive=self.archive)
+        self.backend_write_archive = PuppetForge(max_items=2, archive=self.archive)
+        self.backend_read_archive = PuppetForge(max_items=2, archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):


### PR DESCRIPTION
This patch adds two different backend objects (one fetches data from remote a data source and the other one from an archive) in order to ensure that backend and method params are initialized in the same way independently from which method is called (fetch or fetch_from_archive)