### PR TITLE
[backend] Include available category options in the helptext

### DIFF
--- a/perceval/backends/puppet/puppetforge.py
+++ b/perceval/backends/puppet/puppetforge.py
@@ -342,11 +342,12 @@ class PuppetForgeCommand(BackendCommand):
 
     BACKEND = PuppetForge
 
-    @staticmethod
-    def setup_cmd_parser():
+    @classmethod
+    def setup_cmd_parser(cls):
         """Returns the Puppet Forge argument parser."""
 
-        parser = BackendCommandArgumentParser(from_date=True,
+        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+                                              from_date=True,
                                               archive=True)
 
         # Puppet Forge options

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ try:
     import pypandoc
     long_description = pypandoc.convert(readme_md, 'rst')
 except (IOError, ImportError):
-    print("Warning: pypandoc module not found, or pandoc not installed. " +
+    print("Warning: pypandoc module not found, or pandoc not installed. "
           "Using md instead of rst")
     with codecs.open(readme_md, encoding='utf-8') as f:
         long_description = f.read()

--- a/tests/test_puppetforge.py
+++ b/tests/test_puppetforge.py
@@ -464,6 +464,7 @@ class TestPuppetForgeCommand(unittest.TestCase):
 
         parser = PuppetForgeCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
+        self.assertEqual(parser._categories, PuppetForge.CATEGORIES)
 
         args = ['--max-items', '5',
                 '--tag', 'test',


### PR DESCRIPTION
Minor update in PuppetForge backend to include available category options to the helptext and align it to the parent Backend.
@valeriocos @sduenas, please see if this is good and I will update the other two backends similarly.