### PR TITLE
[puppetforge] Add search fields

### DIFF
--- a/perceval/backends/puppet/puppetforge.py
+++ b/perceval/backends/puppet/puppetforge.py
@@ -50,9 +50,13 @@ class PuppetForge(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve data
     """
-    version = '0.4.2'
+    version = '0.5.0'
 
     CATEGORIES = [CATEGORY_MODULE]
+    EXTRA_SEARCH_FIELDS = {
+        'module_group': ['module_group'],
+        'slug': ['slug']
+    }
 
     def __init__(self, max_items=MAX_ITEMS, tag=None, archive=None):
         origin = PUPPET_FORGE_URL

--- a/tests/test_puppetforge.py
+++ b/tests/test_puppetforge.py
@@ -288,6 +288,36 @@ class TestPuppetForgeBackend(unittest.TestCase):
         for i in range(len(expected)):
             self.assertDictEqual(http_requests[i].querystring, expected[i])
 
+    @httpretty.activate
+    def test_search_fields(self):
+        """Test whether the search_fields is properly set"""
+
+        setup_http_server()
+
+        forge = PuppetForge(max_items=2)
+        modules = [module for module in forge.fetch()]
+
+        module = modules[0]
+        self.assertEqual(forge.metadata_id(module['data']), module['search_fields']['item_id'])
+        self.assertEqual(module['data']['module_group'], 'base')
+        self.assertEqual(module['data']['module_group'], module['search_fields']['module_group'])
+        self.assertEqual(module['data']['slug'], 'norisnetwork-ceph')
+        self.assertEqual(module['data']['slug'], module['search_fields']['slug'])
+
+        module = modules[1]
+        self.assertEqual(forge.metadata_id(module['data']), module['search_fields']['item_id'])
+        self.assertEqual(module['data']['module_group'], 'base')
+        self.assertEqual(module['data']['module_group'], module['search_fields']['module_group'])
+        self.assertEqual(module['data']['slug'], 'sshuyskiy-nomad')
+        self.assertEqual(module['data']['slug'], module['search_fields']['slug'])
+
+        module = modules[2]
+        self.assertEqual(forge.metadata_id(module['data']), module['search_fields']['item_id'])
+        self.assertEqual(module['data']['module_group'], 'base')
+        self.assertEqual(module['data']['module_group'], module['search_fields']['module_group'])
+        self.assertEqual(module['data']['slug'], 'sshuyskiy-consul')
+        self.assertEqual(module['data']['slug'], module['search_fields']['slug'])
+
     def test_parse_json(self):
         """Test if it parses a JSON stream"""
 


### PR DESCRIPTION
This code extends the Puppetforge backend by including a set of search fields to simplify query operations. The search fields introduced are: item_id, module_group, slug.

Tests have been added accordingly.
The backend version is set to 0.5.0.