### PR TITLE
[backend] Change signature BackendCommandArgumentParser

### DIFF
--- a/perceval/backends/puppet/puppetforge.py
+++ b/perceval/backends/puppet/puppetforge.py
@@ -349,7 +349,7 @@ class PuppetForgeCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Puppet Forge argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               archive=True)
 

--- a/tests/test_puppetforge.py
+++ b/tests/test_puppetforge.py
@@ -493,7 +493,7 @@ class TestPuppetForgeCommand(unittest.TestCase):
 
         parser = PuppetForgeCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, PuppetForge.CATEGORIES)
+        self.assertEqual(parser._backend, PuppetForge)
 
         args = ['--max-items', '5',
                 '--tag', 'test',


### PR DESCRIPTION
This code changes the signature of the class `BackendCommandArgumentParser`,
which now accepts as first parameter the backend object instead
its categories. This change is needed to simplify accessing other backend
attributes, beyond the categories.

Puppetforge backend and corresponding tests have been updated.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>