### PR TITLE
Migrate files for branch rename from master to main

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,4 +9,4 @@ jobs:
   check-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: bitergia/release-tools-check-changelog@master
+      - uses: bitergia/release-tools-check-changelog@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build package using Poetry and store result
-        uses: chaoss/grimoirelab-github-actions/build@master
+        uses: chaoss/grimoirelab-github-actions/build@main
         with:
           artifact-name: puppet-dist
           artifact-path: dist
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create a new release on the repository
-        uses: chaoss/grimoirelab-github-actions/release@master
+        uses: chaoss/grimoirelab-github-actions/release@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish the package on PyPI
-        uses: chaoss/grimoirelab-github-actions/publish@master
+        uses: chaoss/grimoirelab-github-actions/publish@main
         with:
           artifact-name: puppet-dist
           artifact-path: dist

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# perceval-puppet [![Build Status](https://github.com/chaoss/grimoirelab-perceval-puppet/workflows/tests/badge.svg)](https://github.com/chaoss/grimoirelab-perceval-puppet/actions?query=workflow:tests+branch:master+event:push) [![Coverage Status](https://img.shields.io/coveralls/chaoss/grimoirelab-perceval-puppet.svg)](https://coveralls.io/r/chaoss/grimoirelab-perceval-puppet?branch=master)  [![PyPI version](https://badge.fury.io/py/perceval-puppet.svg)](https://badge.fury.io/py/perceval-puppet)
+# perceval-puppet [![Build Status](https://github.com/chaoss/grimoirelab-perceval-puppet/workflows/tests/badge.svg)](https://github.com/chaoss/grimoirelab-perceval-puppet/actions?query=workflow:tests+branch:main+event:push) [![Coverage Status](https://img.shields.io/coveralls/chaoss/grimoirelab-perceval-puppet.svg)](https://coveralls.io/r/chaoss/grimoirelab-perceval-puppet?branch=main)  [![PyPI version](https://badge.fury.io/py/perceval-puppet.svg)](https://badge.fury.io/py/perceval-puppet)
 
 Bundle of Perceval backends for Puppet ecosystem.
 


### PR DESCRIPTION
Update files to support the migration of GrimoireLab repositories as part of the default branch transition from master to main.